### PR TITLE
Abstracted away the cloud driver interface

### DIFF
--- a/sushy_tools/emulator/clouds/base.py
+++ b/sushy_tools/emulator/clouds/base.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2017 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import abc
+import six
+
+
+@six.add_metaclass(abc.ABCMeta)
+class AbstractCloudDriver(object):
+    """Base class for all cloud drivers"""
+
+    @abc.abstractproperty
+    def domains(self):
+        """Return available domains
+
+        :returns: list of domain names.
+        """
+
+    @abc.abstractmethod
+    def uuid(self, identity):
+        """Get domain UUID
+
+        :returns: domain UUID
+        """
+
+    @abc.abstractmethod
+    def power_state(self, domain, state=None):
+        """Get/Set domain power state
+
+        :returns: `True` if power is UP and `False` otherwise
+        """
+
+    @abc.abstractmethod
+    def boot_device(self, domain, boot_source=None):
+        """Get/Set domain boot device name
+
+        :returns: boot device name as `str`
+        """
+
+    @abc.abstractmethod
+    def boot_mode(self, domain, boot_source=None):
+        """Get/Set domain boot mode - BIOS vs UEFI
+
+        :returns: boot mode
+        """
+
+    @abc.abstractmethod
+    def total_memory(self, domain):
+        """Get domain total memory
+
+        :returns: available RAM in GB as `int`
+        """
+
+    @abc.abstractmethod
+    def total_cpus(self, domain):
+        """Get domain total count of available CPUs
+
+        :returns: available CPU count as `int`
+        """

--- a/sushy_tools/emulator/clouds/libvirtdriver.py
+++ b/sushy_tools/emulator/clouds/libvirtdriver.py
@@ -1,0 +1,180 @@
+#
+# Copyright 2017 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import xml.etree.ElementTree as ET
+
+from sushy_tools.emulator.clouds.base import AbstractCloudDriver
+from sushy_tools.error import FishyError
+
+import libvirt
+
+
+class LibvirtCloudDriver(AbstractCloudDriver):
+    """Libvirt cloud driver"""
+
+    BOOT_DEVICE_MAP = {
+        'Pxe': 'network',
+        'Hdd': 'hd',
+        'Cd': 'cdrom',
+    }
+
+    BOOT_DEVICE_MAP_REV = {v: k for k, v in BOOT_DEVICE_MAP.items()}
+
+    def __init__(self, uri, readonly=False):
+
+        try:
+            self._conn = (libvirt.openReadOnly(uri)
+                          if readonly else libvirt.open(uri))
+
+        except libvirt.libvirtError as e:
+            msg = ('Error when connecting to the libvirt URI "%(uri)s": '
+                   '%(error)s' % {'uri': self.uri, 'error': e})
+
+            raise FishyError(msg)
+
+    @property
+    def domains(self):
+        """Return available domains
+
+        :returns: list of domain names.
+        """
+        return self._conn.listDefinedDomains()
+
+    def uuid(self, identity):
+        """Get domain UUID
+
+        :returns: domain UUID
+        """
+        domain = self._conn.lookupByName(identity)
+
+        return domain.UUIDString()
+
+    def power_state(self, identity, state=None):
+        """Get/Set domain power state
+
+        :returns: `True` if power is UP and `False` otherwise
+        """
+        domain = self._conn.lookupByName(identity)
+
+        if not state:
+            return 'On' if domain.isActive() else 'Off'
+
+        try:
+            if state in ('On', 'ForceOn'):
+                if not domain.isActive():
+                    domain.create()
+            elif state == 'ForceOff':
+                if domain.isActive():
+                    domain.destroy()
+            elif state == 'GracefulShutdown':
+                if domain.isActive():
+                    domain.shutdown()
+            elif state == 'GracefulRestart':
+                if domain.isActive():
+                    domain.reboot()
+            elif state == 'ForceRestart':
+                if domain.isActive():
+                    domain.reset()
+            elif state == 'Nmi':
+                if domain.isActive():
+                    domain.injectNMI()
+
+        except libvirt.libvirtError as e:
+            msg = ('Error changing power state at libvirt URI "%(uri)s": '
+                   '%(error)s' % {'uri': self.uri, 'error': e})
+
+            raise FishyError(msg)
+
+        return ''
+
+    def boot_device(self, identity, boot_source=None):
+        """Get/Set domain boot device name
+
+        :returns: boot device name as `str`
+        """
+        domain = self._conn.lookupByName(identity)
+
+        tree = ET.fromstring(domain.XMLDesc())
+
+        if boot_source:
+            try:
+                target = self.BOOT_DEVICE_MAP[boot_source]
+
+            except KeyError:
+                msg = ('Unknown power state requested: '
+                       '%(boot_source)s' % {'boot_source': boot_source})
+
+                raise FishyError(msg)
+
+            for os_element in tree.findall('os'):
+                # Remove all "boot" elements
+                for boot_element in os_element.findall('boot'):
+                    os_element.remove(boot_element)
+
+                # Add a new boot element with the request boot device
+                boot_element = ET.SubElement(os_element, 'boot')
+                boot_element.set('dev', target)
+
+            self._conn.defineXML(ET.tostring(tree).decode('utf-8'))
+
+        else:
+            boot_source_target = None
+            boot_element = tree.find('.//boot')
+            if boot_element is not None:
+                boot_source_target = (
+                    self.BOOT_DEVICE_MAP_REV.get(boot_element.get('dev'))
+                )
+
+            return boot_source_target
+
+    def boot_mode(self, identity, boot_source=None):
+        """Get/Set domain boot mode - BIOS vs UEFI
+
+        :returns: boot mode
+        """
+
+    def total_memory(self, identity):
+        """Get domain total memory
+
+        :returns: available RAM in GB as `int`
+        """
+        domain = self._conn.lookupByName(identity)
+
+        return int(domain.maxMemory() / 1024 / 1024)
+
+    def total_cpus(self, identity):
+        """Get domain total count of available CPUs
+
+        :returns: available CPU count as `int`
+        """
+        domain = self._conn.lookupByName(identity)
+
+        tree = ET.fromstring(domain.XMLDesc())
+
+        total_cpus = 0
+
+        if domain.isActive():
+            total_cpus = domain.maxVcpus()
+
+        else:
+            # If we can't get it from maxVcpus() try to find it by
+            # inspecting the domain XML
+            if total_cpus <= 0:
+                vcpu_element = tree.find('.//vcpu')
+                if vcpu_element is not None:
+                    total_cpus = int(vcpu_element.text)
+
+        return total_cpus

--- a/sushy_tools/emulator/main.py
+++ b/sushy_tools/emulator/main.py
@@ -17,52 +17,18 @@
 
 import argparse
 import ssl
-import xml.etree.ElementTree as ET
 
 import flask
-import libvirt
+
+from sushy_tools.emulator.clouds import libvirtdriver
+from sushy_tools.error import FishyError
+
 
 app = flask.Flask(__name__)
 # Turn off strict_slashes on all routes
 app.url_map.strict_slashes = False
 
-LIBVIRT_URI = None
-
-BOOT_DEVICE_MAP = {
-    'Pxe': 'network',
-    'Hdd': 'hd',
-    'Cd': 'cdrom',
-}
-
-BOOT_DEVICE_MAP_REV = {v: k for k, v in BOOT_DEVICE_MAP.items()}
-
-
-class libvirt_open(object):
-
-    def __init__(self, uri, readonly=False):
-        self.uri = uri
-        self.readonly = readonly
-
-    def __enter__(self):
-        try:
-            self._conn = (libvirt.openReadOnly(self.uri)
-                          if self.readonly else
-                          libvirt.open(self.uri))
-            return self._conn
-        except libvirt.libvirtError as e:
-            print('Error when connecting to the libvirt URI "%(uri)s": '
-                  '%(error)s' % {'uri': self.uri, 'error': e})
-            flask.abort(500)
-
-    def __exit__(self, type, value, traceback):
-        self._conn.close()
-
-
-def get_libvirt_domain(connection, domain):
-    try:
-        return connection.lookupByName(domain)
-    except libvirt.libvirtError:
-        flask.abort(404)
+lvCloudDriver = None
 
 
 @app.route('/redfish/v1/')
@@ -72,59 +38,31 @@ def root_resource():
 
 @app.route('/redfish/v1/Systems')
 def system_collection_resource():
-    with libvirt_open(LIBVIRT_URI, readonly=True) as conn:
-        domains = conn.listDefinedDomains()
-        return flask.render_template(
-            'system_collection.json', system_count=len(domains),
-            systems=domains)
+    domains = lvCloudDriver.domains
 
-
-def _get_total_cpus(domain, tree):
-    total_cpus = 0
-    if domain.isActive():
-        total_cpus = domain.maxVcpus()
-    else:
-        # If we can't get it from maxVcpus() try to find it by
-        # inspecting the domain XML
-        if total_cpus <= 0:
-            vcpu_element = tree.find('.//vcpu')
-            if vcpu_element is not None:
-                total_cpus = int(vcpu_element.text)
-    return total_cpus
-
-
-def _get_boot_source_target(tree):
-    boot_source_target = None
-    boot_element = tree.find('.//boot')
-    if boot_element is not None:
-        boot_source_target = (
-            BOOT_DEVICE_MAP_REV.get(boot_element.get('dev')))
-    return boot_source_target
+    return flask.render_template(
+        'system_collection.json', system_count=len(domains),
+        systems=domains)
 
 
 @app.route('/redfish/v1/Systems/<identity>', methods=['GET', 'PATCH'])
 def system_resource(identity):
     if flask.request.method == 'GET':
-        with libvirt_open(LIBVIRT_URI, readonly=True) as conn:
-            domain = get_libvirt_domain(conn, identity)
-            power_state = 'On' if domain.isActive() else 'Off'
-            total_memory_gb = int(domain.maxMemory() / 1024 / 1024)
 
-            tree = ET.fromstring(domain.XMLDesc())
-            total_cpus = _get_total_cpus(domain, tree)
-            boot_source_target = _get_boot_source_target(tree)
-
-            return flask.render_template(
-                'system.json', identity=identity, uuid=domain.UUIDString(),
-                power_state=power_state, total_memory_gb=total_memory_gb,
-                total_cpus=total_cpus, boot_source_target=boot_source_target)
+        return flask.render_template(
+            'system.json', identity=identity,
+            uuid=lvCloudDriver.uuid(identity),
+            power_state=lvCloudDriver.power_state(identity),
+            total_memory_gb=lvCloudDriver.total_memory(identity),
+            total_cpus=lvCloudDriver.total_cpus(identity),
+            boot_source_target=lvCloudDriver.boot_device(identity))
 
     elif flask.request.method == 'PATCH':
         boot = flask.request.json.get('Boot')
         if not boot:
             return 'PATCH only works for the Boot element', 400
 
-        target = BOOT_DEVICE_MAP.get(boot.get('BootSourceOverrideTarget'))
+        target = boot.get('BootSourceOverrideTarget')
         if not target:
             return 'Missing the BootSourceOverrideTarget element', 400
 
@@ -135,19 +73,11 @@ def system_resource(identity):
         # TODO(lucasagomes): We should allow changing the boot mode from
         # BIOS to UEFI (and vice-versa)
 
-        with libvirt_open(LIBVIRT_URI) as conn:
-            domain = get_libvirt_domain(conn, identity)
-            tree = ET.fromstring(domain.XMLDesc())
-            for os_element in tree.findall('os'):
-                # Remove all "boot" elements
-                for boot_element in os_element.findall('boot'):
-                    os_element.remove(boot_element)
+        try:
+            lvCloudDriver.boot_device(identity, target)
 
-                # Add a new boot element with the request boot device
-                boot_element = ET.SubElement(os_element, 'boot')
-                boot_element.set('dev', target)
-
-            conn.defineXML(ET.tostring(tree).decode('utf-8'))
+        except FishyError:
+            flask.abort(500)
 
         return '', 204
 
@@ -156,29 +86,12 @@ def system_resource(identity):
            methods=['POST'])
 def system_reset_action(identity):
     reset_type = flask.request.json.get('ResetType')
-    with libvirt_open(LIBVIRT_URI) as conn:
-        domain = get_libvirt_domain(conn, identity)
-        try:
-            if reset_type in ('On', 'ForceOn'):
-                if not domain.isActive():
-                    domain.create()
-            elif reset_type == 'ForceOff':
-                if domain.isActive():
-                    domain.destroy()
-            elif reset_type == 'GracefulShutdown':
-                if domain.isActive():
-                    domain.shutdown()
-            elif reset_type == 'GracefulRestart':
-                if domain.isActive():
-                    domain.reboot()
-            elif reset_type == 'ForceRestart':
-                if domain.isActive():
-                    domain.reset()
-            elif reset_type == 'Nmi':
-                if domain.isActive():
-                    domain.injectNMI()
-        except libvirt.libvirtError:
-            flask.abort(500)
+
+    try:
+        lvCloudDriver.power_state(identity, reset_type)
+
+    except FishyError:
+        flask.abort(500)
 
     return '', 204
 
@@ -203,9 +116,11 @@ def parse_args():
 
 
 def main():
-    global LIBVIRT_URI
+    global lvCloudDriver
+
     args = parse_args()
-    LIBVIRT_URI = args.libvirt_uri
+
+    lvCloudDriver = libvirtdriver.LibvirtCloudDriver(args.libvirt_uri)
 
     ssl_context = None
     if args.ssl_certificate and args.ssl_key:

--- a/sushy_tools/error.py
+++ b/sushy_tools/error.py
@@ -1,0 +1,19 @@
+#
+# Copyright 2017 Red Hat, Inc.
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+class FishyError(Exception):
+    """Create generic sushy-tools exception object"""


### PR DESCRIPTION
This PR decouples cloud drivers (presently just libvirt) from the Redfish REST API server. The purpose is to be able to support multiple clouds in parallel by way of dedicated and unified drivers. Most immediate candidate would be novaclient (e.g. OpenStack API).

The change itself is two-step:

* introduced an abstract base class for cloud driver
* instituted the libvirt driver and moved all the existing libvirt code into the libvirt driver

There should be no change in functionality of the libvirt driver.