### PR TITLE
Use listAllDomains() instead of listDefinedDomains() because:

### DIFF
--- a/sushy_tools/emulator/drivers/libvirtdriver.py
+++ b/sushy_tools/emulator/drivers/libvirtdriver.py
@@ -144,7 +144,7 @@ class LibvirtDriver(AbstractDriver):
         """
         with libvirt_open(self._uri, readonly=True) as conn:
             return [domain.UUIDString()
-                    for domain in conn.listDefinedDomains()]
+                    for domain in conn.listAllDomains(0)]
 
     def uuid(self, identity):
         """Get computer system UUID


### PR DESCRIPTION
a) listDefinedDomains() returns str object which has no attribute UUIDString
b) listDefinedDomains() returns only guests that are _not_ running

Hello,

Few notes to the patch:

ad a)
Using dynamic emulator and accessing https://localhost:8000/redfish/v1/Systems/ returns with latest sushy-tools code this:
{
  "error": {
    "code": "Base.1.0.GeneralError",
    "message": "\u0027str\u0027 object has no attribute \u0027UUIDString\u0027",
    "@Message.ExtendedInfo": [
      {
        "@odata.type": "/redfish/v1/$metadata#Message.1.0.0.Message",
        "MessageId": "Base.1.0.GeneralError"
      }
    ]
  }
}

ad b)
Please see [1] for more information.

This PR should fix both issues.

[1] https://github.com/dell/redfish-ansible-module/issues/83