### PR TITLE
Defining an extras section for easier install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,3 +42,9 @@ input_file = sushy_tools/locale/sushy_tools.pot
 keywords = _ gettext ngettext l_ lazy_gettext
 mapping_file = babel.cfg
 output_file = sushy_tools/locale/sushy_tools.pot
+
+[extras]
+libvirt =
+    libvirt-python
+nova =
+    openstacksdk


### PR DESCRIPTION
The install doc mentions you should install either of the two packages, but having the optional drivers as extras offered in the package itself seems more user friendly.