### PR TITLE
Restore error handling in decorator »ensure_instance_access«.

### DIFF
--- a/sushy_tools/emulator/api_utils.py
+++ b/sushy_tools/emulator/api_utils.py
@@ -14,6 +14,8 @@ import functools
 
 import flask
 
+from sushy_tools import error
+
 
 def warning(*args, **kwargs):
     flask.current_app.logger.warning(*args, **kwargs)

--- a/sushy_tools/emulator/api_utils.py
+++ b/sushy_tools/emulator/api_utils.py
@@ -15,20 +15,8 @@ import functools
 import flask
 
 
-def debug(*args, **kwargs):
-    flask.current_app.logger.debug(*args, **kwargs)
-
-
-def info(*args, **kwargs):
-    flask.current_app.logger.info(*args, **kwargs)
-
-
 def warning(*args, **kwargs):
     flask.current_app.logger.warning(*args, **kwargs)
-
-
-def error(*args, **kwargs):
-    flask.current_app.logger.error(*args, **kwargs)
 
 
 def instance_denied(**kwargs):


### PR DESCRIPTION
By accident, the _error_ function in module _api_utils_ logically shadowed the (not even imported) _error_ module, thus breaking the reference to `error.NotFound` in decorator _ensure_instance_access_.

This PR restores the reference, restoring the presumably intended behaviour.